### PR TITLE
Refactor heritage site display and add individual pages for each site

### DIFF
--- a/viraasat/package-lock.json
+++ b/viraasat/package-lock.json
@@ -10,7 +10,10 @@
       "dependencies": {
         "@react-three/drei": "^10.7.6",
         "@react-three/fiber": "^9.3.0",
+        "framer-motion": "^12.23.16",
+        "gl-matrix": "^3.4.4",
         "lucide-react": "^0.544.0",
+        "motion": "^12.23.16",
         "next": "15.5.3",
         "react": "19.1.0",
         "react-dom": "19.1.0",
@@ -3567,6 +3570,33 @@
         "url": "https://github.com/sponsors/rawify"
       }
     },
+    "node_modules/framer-motion": {
+      "version": "12.23.16",
+      "resolved": "https://registry.npmjs.org/framer-motion/-/framer-motion-12.23.16.tgz",
+      "integrity": "sha512-N81A8hiHqVsexOzI3wzkibyLURW1nEJsZaRuctPhG4AdbbciYu+bKJq9I2lQFzAO4Bx3h4swI6pBbF/Hu7f7BA==",
+      "license": "MIT",
+      "dependencies": {
+        "motion-dom": "^12.23.12",
+        "motion-utils": "^12.23.6",
+        "tslib": "^2.4.0"
+      },
+      "peerDependencies": {
+        "@emotion/is-prop-valid": "*",
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@emotion/is-prop-valid": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "react-dom": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/fsevents": {
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
@@ -3692,6 +3722,12 @@
       "funding": {
         "url": "https://github.com/privatenumber/get-tsconfig?sponsor=1"
       }
+    },
+    "node_modules/gl-matrix": {
+      "version": "3.4.4",
+      "resolved": "https://registry.npmjs.org/gl-matrix/-/gl-matrix-3.4.4.tgz",
+      "integrity": "sha512-latSnyDNt/8zYUB6VIJ6PCh2jBjJX6gnDsoCZ7LyW7GkqrD51EWwa9qCoGixj8YqBtETQK/xY7OmpTF8xz1DdQ==",
+      "license": "MIT"
     },
     "node_modules/glob": {
       "version": "10.4.5",
@@ -4783,6 +4819,47 @@
       "engines": {
         "node": ">=16 || 14 >=14.17"
       }
+    },
+    "node_modules/motion": {
+      "version": "12.23.16",
+      "resolved": "https://registry.npmjs.org/motion/-/motion-12.23.16.tgz",
+      "integrity": "sha512-8vVuxZgcfGZm4kgSqFgGrhQ+6034y4UuEsqCX8s7UYeoQ+NO3R9LV5AyDlVr2Mb7xvS7ZM5s/XkTurWbWQ+UHA==",
+      "license": "MIT",
+      "dependencies": {
+        "framer-motion": "^12.23.16",
+        "tslib": "^2.4.0"
+      },
+      "peerDependencies": {
+        "@emotion/is-prop-valid": "*",
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@emotion/is-prop-valid": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/motion-dom": {
+      "version": "12.23.12",
+      "resolved": "https://registry.npmjs.org/motion-dom/-/motion-dom-12.23.12.tgz",
+      "integrity": "sha512-RcR4fvMCTESQBD/uKQe49D5RUeDOokkGRmz4ceaJKDBgHYtZtntC/s2vLvY38gqGaytinij/yi3hMcWVcEF5Kw==",
+      "license": "MIT",
+      "dependencies": {
+        "motion-utils": "^12.23.6"
+      }
+    },
+    "node_modules/motion-utils": {
+      "version": "12.23.6",
+      "resolved": "https://registry.npmjs.org/motion-utils/-/motion-utils-12.23.6.tgz",
+      "integrity": "sha512-eAWoPgr4eFEOFfg2WjIsMoqJTW6Z8MTUCgn/GZ3VRpClWBdnbjryiA3ZSNLyxCTmCQx4RmYX6jX1iWHbenUPNQ==",
+      "license": "MIT"
     },
     "node_modules/ms": {
       "version": "2.1.3",

--- a/viraasat/package.json
+++ b/viraasat/package.json
@@ -11,7 +11,10 @@
   "dependencies": {
     "@react-three/drei": "^10.7.6",
     "@react-three/fiber": "^9.3.0",
+    "framer-motion": "^12.23.16",
+    "gl-matrix": "^3.4.4",
     "lucide-react": "^0.544.0",
+    "motion": "^12.23.16",
     "next": "15.5.3",
     "react": "19.1.0",
     "react-dom": "19.1.0",

--- a/viraasat/src/app/components/CountUp.jsx
+++ b/viraasat/src/app/components/CountUp.jsx
@@ -1,0 +1,96 @@
+"use client";
+
+import { useEffect, useRef } from 'react';
+import { useInView, useMotionValue, useSpring } from 'motion/react';
+
+export default function CountUp({
+  to,
+  from = 0,
+  direction = 'up',
+  delay = 0,
+  duration = 1.2,
+  className = '',
+  startWhen = true,
+  separator = '',
+  onStart,
+  onEnd
+}) {
+  const ref = useRef(null);
+  const motionValue = useMotionValue(direction === 'down' ? to : from);
+
+  const damping = 20 + 40 * (1 / duration);
+  const stiffness = 100 * (1 / duration);
+
+  const springValue = useSpring(motionValue, {
+    damping,
+    stiffness
+  });
+
+  const isInView = useInView(ref, { once: true, margin: '0px' });
+
+  const getDecimalPlaces = num => {
+    const str = num.toString();
+
+    if (str.includes('.')) {
+      const decimals = str.split('.')[1];
+
+      if (parseInt(decimals) !== 0) {
+        return decimals.length;
+      }
+    }
+
+    return 0;
+  };
+
+  const maxDecimals = Math.max(getDecimalPlaces(from), getDecimalPlaces(to));
+
+  useEffect(() => {
+    if (ref.current) {
+      ref.current.textContent = String(direction === 'down' ? to : from);
+    }
+  }, [from, to, direction]);
+
+  useEffect(() => {
+    if (isInView && startWhen) {
+      if (typeof onStart === 'function') onStart();
+
+      const timeoutId = setTimeout(() => {
+        motionValue.set(direction === 'down' ? from : to);
+      }, delay * 1000);
+
+      const durationTimeoutId = setTimeout(
+        () => {
+          if (typeof onEnd === 'function') onEnd();
+        },
+        delay * 1000 + duration * 1000
+      );
+
+      return () => {
+        clearTimeout(timeoutId);
+        clearTimeout(durationTimeoutId);
+      };
+    }
+  }, [isInView, startWhen, motionValue, direction, from, to, delay, onStart, onEnd, duration]);
+
+  useEffect(() => {
+    const unsubscribe = springValue.on('change', latest => {
+      if (ref.current) {
+        const hasDecimals = maxDecimals > 0;
+
+        const options = {
+          useGrouping: !!separator,
+          minimumFractionDigits: hasDecimals ? maxDecimals : 0,
+          maximumFractionDigits: hasDecimals ? maxDecimals : 0
+        };
+
+        const formattedNumber = Intl.NumberFormat('en-US', options).format(latest);
+
+        ref.current.textContent = separator ? formattedNumber.replace(/,/g, separator) : formattedNumber;
+      }
+    });
+
+    return () => unsubscribe();
+  }, [springValue, separator, maxDecimals]);
+
+  return <span className={className} ref={ref} />;
+}

--- a/viraasat/src/app/components/Impact.jsx
+++ b/viraasat/src/app/components/Impact.jsx
@@ -1,6 +1,7 @@
-'use client';
+"use client";
 
 import { useState, useEffect, useRef } from 'react';
+import CountUp from './CountUp';
 
 export default function Impact() {
   const [isVisible, setIsVisible] = useState(false);
@@ -41,7 +42,7 @@ export default function Impact() {
     }
   ];
   
-  const [countedStats, setCountedStats] = useState(stats.map(() => 0));
+  // countedStats state and interval-based counting removed in favor of CountUp
   const testimonials = [
     {
       quote: "Viraasat has revolutionized how we teach history. Students are more engaged than ever.",
@@ -62,34 +63,6 @@ export default function Impact() {
       ([entry]) => {
         if (entry.isIntersecting) {
           setIsVisible(true);
-          
-          // Animate counting up the stats with proper cleanup
-          const timers = stats.map((stat, index) => {
-            const target = stat.endValue;
-            const duration = 2000;
-            const steps = 60;
-            const increment = target / steps;
-            let current = 0;
-            
-            return setInterval(() => {
-              current += increment;
-              if (current >= target) {
-                current = target;
-                clearInterval(timers[index]);
-              }
-              
-              setCountedStats(prev => {
-                const newStats = [...prev];
-                newStats[index] = Math.floor(current);
-                return newStats;
-              });
-            }, duration / steps);
-          });
-          
-          // Cleanup function to clear all intervals
-          return () => {
-            timers.forEach(timer => clearInterval(timer));
-          };
         }
       },
       { threshold: 0.3 }
@@ -104,7 +77,7 @@ export default function Impact() {
         observer.unobserve(sectionRef.current);
       }
     };
-  }, [stats]);
+  }, []);
 
   return (
     <section ref={sectionRef} className="py-28 bg-background relative overflow-hidden">
@@ -143,14 +116,25 @@ export default function Impact() {
               <div className={`w-16 h-16 mx-auto mb-4 bg-gradient-to-br ${stat.color} rounded-2xl flex items-center justify-center text-2xl text-background`}>
                 {stat.icon}
               </div>
-              <div className="text-4xl md:text-5xl font-bold text-primary mb-2">
-                {stat.number.includes('%') 
-                  ? `${countedStats[index]}%` 
-                  : stat.number.includes('M+')
-                    ? `${countedStats[index]}M+`
-                    : `${countedStats[index]}+`
-                }
-              </div>
+                  <div className="text-4xl md:text-5xl font-bold text-primary mb-2">
+                    {/* Use CountUp component to animate numbers reliably */}
+                    {stat.number.includes('%') ? (
+                      <CountUp
+                        to={stat.endValue}
+                         duration={1.2}
+                        className="inline-block"
+                        separator={''}
+                      />
+                    ) : stat.number.includes('M+') ? (
+                      <>
+                         <CountUp to={stat.endValue} duration={1.2} className="inline-block" />M+
+                      </>
+                    ) : (
+                      <>
+                         <CountUp to={stat.endValue} duration={1.2} className="inline-block" />+
+                      </>
+                    )}
+                  </div>
               <div className="text-lg font-semibold text-text-primary mb-2">{stat.label}</div>
               <div className="text-text-secondary text-sm">{stat.description}</div>
             </div>

--- a/viraasat/src/app/components/InfiniteMenu.jsx
+++ b/viraasat/src/app/components/InfiniteMenu.jsx
@@ -1,0 +1,1050 @@
+'use client';
+
+import { useEffect, useRef, useState } from 'react';
+import { useRouter } from 'next/navigation';
+import { mat4, quat, vec2, vec3 } from 'gl-matrix';
+
+const discVertShaderSource = `#version 300 es
+
+uniform mat4 uWorldMatrix;
+uniform mat4 uViewMatrix;
+uniform mat4 uProjectionMatrix;
+uniform vec3 uCameraPosition;
+uniform vec4 uRotationAxisVelocity;
+
+in vec3 aModelPosition;
+in vec3 aModelNormal;
+in vec2 aModelUvs;
+in mat4 aInstanceMatrix;
+
+out vec2 vUvs;
+out float vAlpha;
+flat out int vInstanceId;
+
+#define PI 3.141593
+
+void main() {
+    vec4 worldPosition = uWorldMatrix * aInstanceMatrix * vec4(aModelPosition, 1.);
+
+    vec3 centerPos = (uWorldMatrix * aInstanceMatrix * vec4(0., 0., 0., 1.)).xyz;
+    float radius = length(centerPos.xyz);
+
+    if (gl_VertexID > 0) {
+        vec3 rotationAxis = uRotationAxisVelocity.xyz;
+        float rotationVelocity = min(.15, uRotationAxisVelocity.w * 15.);
+        vec3 stretchDir = normalize(cross(centerPos, rotationAxis));
+        vec3 relativeVertexPos = normalize(worldPosition.xyz - centerPos);
+        float strength = dot(stretchDir, relativeVertexPos);
+        float invAbsStrength = min(0., abs(strength) - 1.);
+        strength = rotationVelocity * sign(strength) * abs(invAbsStrength * invAbsStrength * invAbsStrength + 1.);
+        worldPosition.xyz += stretchDir * strength;
+    }
+
+    worldPosition.xyz = radius * normalize(worldPosition.xyz);
+
+    gl_Position = uProjectionMatrix * uViewMatrix * worldPosition;
+
+    vAlpha = smoothstep(0.5, 1., normalize(worldPosition.xyz).z) * .9 + .1;
+    vUvs = aModelUvs;
+    vInstanceId = gl_InstanceID;
+}
+`;
+
+const discFragShaderSource = `#version 300 es
+precision highp float;
+
+uniform sampler2D uTex;
+uniform int uItemCount;
+uniform int uAtlasSize;
+
+out vec4 outColor;
+
+in vec2 vUvs;
+in float vAlpha;
+flat in int vInstanceId;
+
+void main() {
+    int itemIndex = vInstanceId % uItemCount;
+    int cellsPerRow = uAtlasSize;
+    int cellX = itemIndex % cellsPerRow;
+    int cellY = itemIndex / cellsPerRow;
+    vec2 cellSize = vec2(1.0) / vec2(float(cellsPerRow));
+    vec2 cellOffset = vec2(float(cellX), float(cellY)) * cellSize;
+
+    ivec2 texSize = textureSize(uTex, 0);
+    float imageAspect = float(texSize.x) / float(texSize.y);
+    float containerAspect = 1.0;
+    
+    float scale = max(imageAspect / containerAspect, 
+                     containerAspect / imageAspect);
+    
+    vec2 st = vec2(vUvs.x, 1.0 - vUvs.y);
+    st = (st - 0.5) * scale + 0.5;
+    
+    st = clamp(st, 0.0, 1.0);
+    
+    st = st * cellSize + cellOffset;
+    
+    outColor = texture(uTex, st);
+    outColor.a *= vAlpha;
+}
+`;
+
+class Face {
+  constructor(a, b, c) {
+    this.a = a;
+    this.b = b;
+    this.c = c;
+  }
+}
+
+class Vertex {
+  constructor(x, y, z) {
+    this.position = vec3.fromValues(x, y, z);
+    this.normal = vec3.create();
+    this.uv = vec2.create();
+  }
+}
+
+class Geometry {
+  constructor() {
+    this.vertices = [];
+    this.faces = [];
+  }
+
+  addVertex(...args) {
+    for (let i = 0; i < args.length; i += 3) {
+      this.vertices.push(new Vertex(args[i], args[i + 1], args[i + 2]));
+    }
+    return this;
+  }
+
+  addFace(...args) {
+    for (let i = 0; i < args.length; i += 3) {
+      this.faces.push(new Face(args[i], args[i + 1], args[i + 2]));
+    }
+    return this;
+  }
+
+  get lastVertex() {
+    return this.vertices[this.vertices.length - 1];
+  }
+
+  subdivide(divisions = 1) {
+    const midPointCache = {};
+    let f = this.faces;
+
+    for (let div = 0; div < divisions; ++div) {
+      const newFaces = new Array(f.length * 4);
+
+      f.forEach((face, ndx) => {
+        const mAB = this.getMidPoint(face.a, face.b, midPointCache);
+        const mBC = this.getMidPoint(face.b, face.c, midPointCache);
+        const mCA = this.getMidPoint(face.c, face.a, midPointCache);
+
+        const i = ndx * 4;
+        newFaces[i + 0] = new Face(face.a, mAB, mCA);
+        newFaces[i + 1] = new Face(face.b, mBC, mAB);
+        newFaces[i + 2] = new Face(face.c, mCA, mBC);
+        newFaces[i + 3] = new Face(mAB, mBC, mCA);
+      });
+
+      f = newFaces;
+    }
+
+    this.faces = f;
+    return this;
+  }
+
+  spherize(radius = 1) {
+    this.vertices.forEach(vertex => {
+      vec3.normalize(vertex.normal, vertex.position);
+      vec3.scale(vertex.position, vertex.normal, radius);
+    });
+    return this;
+  }
+
+  get data() {
+    return {
+      vertices: this.vertexData,
+      indices: this.indexData,
+      normals: this.normalData,
+      uvs: this.uvData
+    };
+  }
+
+  get vertexData() {
+    return new Float32Array(this.vertices.flatMap(v => Array.from(v.position)));
+  }
+
+  get normalData() {
+    return new Float32Array(this.vertices.flatMap(v => Array.from(v.normal)));
+  }
+
+  get uvData() {
+    return new Float32Array(this.vertices.flatMap(v => Array.from(v.uv)));
+  }
+
+  get indexData() {
+    return new Uint16Array(this.faces.flatMap(f => [f.a, f.b, f.c]));
+  }
+
+  getMidPoint(ndxA, ndxB, cache) {
+    const cacheKey = ndxA < ndxB ? `k_${ndxB}_${ndxA}` : `k_${ndxA}_${ndxB}`;
+    if (Object.prototype.hasOwnProperty.call(cache, cacheKey)) {
+      return cache[cacheKey];
+    }
+    const a = this.vertices[ndxA].position;
+    const b = this.vertices[ndxB].position;
+    const ndx = this.vertices.length;
+    cache[cacheKey] = ndx;
+    this.addVertex((a[0] + b[0]) * 0.5, (a[1] + b[1]) * 0.5, (a[2] + b[2]) * 0.5);
+    return ndx;
+  }
+}
+
+class IcosahedronGeometry extends Geometry {
+  constructor() {
+    super();
+    const t = Math.sqrt(5) * 0.5 + 0.5;
+    this.addVertex(
+      -1,
+      t,
+      0,
+      1,
+      t,
+      0,
+      -1,
+      -t,
+      0,
+      1,
+      -t,
+      0,
+      0,
+      -1,
+      t,
+      0,
+      1,
+      t,
+      0,
+      -1,
+      -t,
+      0,
+      1,
+      -t,
+      t,
+      0,
+      -1,
+      t,
+      0,
+      1,
+      -t,
+      0,
+      -1,
+      -t,
+      0,
+      1
+    ).addFace(
+      0,
+      11,
+      5,
+      0,
+      5,
+      1,
+      0,
+      1,
+      7,
+      0,
+      7,
+      10,
+      0,
+      10,
+      11,
+      1,
+      5,
+      9,
+      5,
+      11,
+      4,
+      11,
+      10,
+      2,
+      10,
+      7,
+      6,
+      7,
+      1,
+      8,
+      3,
+      9,
+      4,
+      3,
+      4,
+      2,
+      3,
+      2,
+      6,
+      3,
+      6,
+      8,
+      3,
+      8,
+      9,
+      4,
+      9,
+      5,
+      2,
+      4,
+      11,
+      6,
+      2,
+      10,
+      8,
+      6,
+      7,
+      9,
+      8,
+      1
+    );
+  }
+}
+
+class DiscGeometry extends Geometry {
+  constructor(steps = 4, radius = 1) {
+    super();
+    steps = Math.max(4, steps);
+
+    const alpha = (2 * Math.PI) / steps;
+
+    this.addVertex(0, 0, 0);
+    this.lastVertex.uv[0] = 0.5;
+    this.lastVertex.uv[1] = 0.5;
+
+    for (let i = 0; i < steps; ++i) {
+      const x = Math.cos(alpha * i);
+      const y = Math.sin(alpha * i);
+      this.addVertex(radius * x, radius * y, 0);
+      this.lastVertex.uv[0] = x * 0.5 + 0.5;
+      this.lastVertex.uv[1] = y * 0.5 + 0.5;
+
+      if (i > 0) {
+        this.addFace(0, i, i + 1);
+      }
+    }
+    this.addFace(0, steps, 1);
+  }
+}
+
+function createShader(gl, type, source) {
+  const shader = gl.createShader(type);
+  gl.shaderSource(shader, source);
+  gl.compileShader(shader);
+  const success = gl.getShaderParameter(shader, gl.COMPILE_STATUS);
+
+  if (success) {
+    return shader;
+  }
+
+  console.error(gl.getShaderInfoLog(shader));
+  gl.deleteShader(shader);
+  return null;
+}
+
+function createProgram(gl, shaderSources, transformFeedbackVaryings, attribLocations) {
+  const program = gl.createProgram();
+
+  [gl.VERTEX_SHADER, gl.FRAGMENT_SHADER].forEach((type, ndx) => {
+    const shader = createShader(gl, type, shaderSources[ndx]);
+    if (shader) gl.attachShader(program, shader);
+  });
+
+  if (transformFeedbackVaryings) {
+    gl.transformFeedbackVaryings(program, transformFeedbackVaryings, gl.SEPARATE_ATTRIBS);
+  }
+
+  if (attribLocations) {
+    for (const attrib in attribLocations) {
+      gl.bindAttribLocation(program, attribLocations[attrib], attrib);
+    }
+  }
+
+  gl.linkProgram(program);
+  const success = gl.getProgramParameter(program, gl.LINK_STATUS);
+
+  if (success) {
+    return program;
+  }
+
+  console.error(gl.getProgramInfoLog(program));
+  gl.deleteProgram(program);
+  return null;
+}
+
+function makeVertexArray(gl, bufLocNumElmPairs, indices) {
+  const va = gl.createVertexArray();
+  gl.bindVertexArray(va);
+
+  for (const [buffer, loc, numElem] of bufLocNumElmPairs) {
+    if (loc === -1) continue;
+    gl.bindBuffer(gl.ARRAY_BUFFER, buffer);
+    gl.enableVertexAttribArray(loc);
+    gl.vertexAttribPointer(loc, numElem, gl.FLOAT, false, 0, 0);
+  }
+
+  if (indices) {
+    const indexBuffer = gl.createBuffer();
+    gl.bindBuffer(gl.ELEMENT_ARRAY_BUFFER, indexBuffer);
+    gl.bufferData(gl.ELEMENT_ARRAY_BUFFER, new Uint16Array(indices), gl.STATIC_DRAW);
+  }
+
+  gl.bindVertexArray(null);
+  return va;
+}
+
+function resizeCanvasToDisplaySize(canvas) {
+  const dpr = Math.min(2, window.devicePixelRatio);
+  const displayWidth = Math.round(canvas.clientWidth * dpr);
+  const displayHeight = Math.round(canvas.clientHeight * dpr);
+  const needResize = canvas.width !== displayWidth || canvas.height !== displayHeight;
+  if (needResize) {
+    canvas.width = displayWidth;
+    canvas.height = displayHeight;
+  }
+  return needResize;
+}
+
+function makeBuffer(gl, sizeOrData, usage) {
+  const buf = gl.createBuffer();
+  gl.bindBuffer(gl.ARRAY_BUFFER, buf);
+  gl.bufferData(gl.ARRAY_BUFFER, sizeOrData, usage);
+  gl.bindBuffer(gl.ARRAY_BUFFER, null);
+  return buf;
+}
+
+function createAndSetupTexture(gl, minFilter, magFilter, wrapS, wrapT) {
+  const texture = gl.createTexture();
+  gl.bindTexture(gl.TEXTURE_2D, texture);
+  gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_S, wrapS);
+  gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_T, wrapT);
+  gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MIN_FILTER, minFilter);
+  gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MAG_FILTER, magFilter);
+  return texture;
+}
+
+class ArcballControl {
+  isPointerDown = false;
+  orientation = quat.create();
+  pointerRotation = quat.create();
+  rotationVelocity = 0;
+  rotationAxis = vec3.fromValues(1, 0, 0);
+  snapDirection = vec3.fromValues(0, 0, -1);
+  snapTargetDirection;
+  EPSILON = 0.1;
+  IDENTITY_QUAT = quat.create();
+
+  constructor(canvas, updateCallback) {
+    this.canvas = canvas;
+    this.updateCallback = updateCallback || (() => null);
+
+    this.pointerPos = vec2.create();
+    this.previousPointerPos = vec2.create();
+    this._rotationVelocity = 0;
+    this._combinedQuat = quat.create();
+
+    canvas.addEventListener('pointerdown', e => {
+      vec2.set(this.pointerPos, e.clientX, e.clientY);
+      vec2.copy(this.previousPointerPos, this.pointerPos);
+      this.isPointerDown = true;
+    });
+    canvas.addEventListener('pointerup', () => {
+      this.isPointerDown = false;
+    });
+    canvas.addEventListener('pointerleave', () => {
+      this.isPointerDown = false;
+    });
+    canvas.addEventListener('pointermove', e => {
+      if (this.isPointerDown) {
+        vec2.set(this.pointerPos, e.clientX, e.clientY);
+      }
+    });
+
+    canvas.style.touchAction = 'none';
+  }
+
+  update(deltaTime, targetFrameDuration = 16) {
+    const timeScale = deltaTime / targetFrameDuration + 0.00001;
+    let angleFactor = timeScale;
+    let snapRotation = quat.create();
+
+    if (this.isPointerDown) {
+      const INTENSITY = 0.3 * timeScale;
+      const ANGLE_AMPLIFICATION = 5 / timeScale;
+
+      const midPointerPos = vec2.sub(vec2.create(), this.pointerPos, this.previousPointerPos);
+      vec2.scale(midPointerPos, midPointerPos, INTENSITY);
+
+      if (vec2.sqrLen(midPointerPos) > this.EPSILON) {
+        vec2.add(midPointerPos, this.previousPointerPos, midPointerPos);
+
+        const p = this.#project(midPointerPos);
+        const q = this.#project(this.previousPointerPos);
+        const a = vec3.normalize(vec3.create(), p);
+        const b = vec3.normalize(vec3.create(), q);
+
+        vec2.copy(this.previousPointerPos, midPointerPos);
+
+        angleFactor *= ANGLE_AMPLIFICATION;
+
+        this.quatFromVectors(a, b, this.pointerRotation, angleFactor);
+      } else {
+        quat.slerp(this.pointerRotation, this.pointerRotation, this.IDENTITY_QUAT, INTENSITY);
+      }
+    } else {
+      const INTENSITY = 0.1 * timeScale;
+      quat.slerp(this.pointerRotation, this.pointerRotation, this.IDENTITY_QUAT, INTENSITY);
+
+      if (this.snapTargetDirection) {
+        const SNAPPING_INTENSITY = 0.2;
+        const a = this.snapTargetDirection;
+        const b = this.snapDirection;
+        const sqrDist = vec3.squaredDistance(a, b);
+        const distanceFactor = Math.max(0.1, 1 - sqrDist * 10);
+        angleFactor *= SNAPPING_INTENSITY * distanceFactor;
+        this.quatFromVectors(a, b, snapRotation, angleFactor);
+      }
+    }
+
+    const combinedQuat = quat.multiply(quat.create(), snapRotation, this.pointerRotation);
+    this.orientation = quat.multiply(quat.create(), combinedQuat, this.orientation);
+    quat.normalize(this.orientation, this.orientation);
+
+    const RA_INTENSITY = 0.8 * timeScale;
+    quat.slerp(this._combinedQuat, this._combinedQuat, combinedQuat, RA_INTENSITY);
+    quat.normalize(this._combinedQuat, this._combinedQuat);
+
+    const rad = Math.acos(this._combinedQuat[3]) * 2.0;
+    const s = Math.sin(rad / 2.0);
+    let rv = 0;
+    if (s > 0.000001) {
+      rv = rad / (2 * Math.PI);
+      this.rotationAxis[0] = this._combinedQuat[0] / s;
+      this.rotationAxis[1] = this._combinedQuat[1] / s;
+      this.rotationAxis[2] = this._combinedQuat[2] / s;
+    }
+
+    const RV_INTENSITY = 0.5 * timeScale;
+    this._rotationVelocity += (rv - this._rotationVelocity) * RV_INTENSITY;
+    this.rotationVelocity = this._rotationVelocity / timeScale;
+
+    this.updateCallback(deltaTime);
+  }
+
+  quatFromVectors(a, b, out, angleFactor = 1) {
+    const axis = vec3.cross(vec3.create(), a, b);
+    vec3.normalize(axis, axis);
+    const d = Math.max(-1, Math.min(1, vec3.dot(a, b)));
+    const angle = Math.acos(d) * angleFactor;
+    quat.setAxisAngle(out, axis, angle);
+    return { q: out, axis, angle };
+  }
+
+  #project(pos) {
+    const r = 2;
+    const w = this.canvas.clientWidth;
+    const h = this.canvas.clientHeight;
+    const s = Math.max(w, h) - 1;
+
+    const x = (2 * pos[0] - w - 1) / s;
+    const y = (2 * pos[1] - h - 1) / s;
+    let z = 0;
+    const xySq = x * x + y * y;
+    const rSq = r * r;
+
+    if (xySq <= rSq / 2.0) {
+      z = Math.sqrt(rSq - xySq);
+    } else {
+      z = rSq / Math.sqrt(xySq);
+    }
+    return vec3.fromValues(-x, y, z);
+  }
+}
+
+class InfiniteGridMenu {
+  TARGET_FRAME_DURATION = 1000 / 60;
+  SPHERE_RADIUS = 2;
+
+  #time = 0;
+  #deltaTime = 0;
+  #deltaFrames = 0;
+  #frames = 0;
+
+  camera = {
+    matrix: mat4.create(),
+    near: 0.1,
+    far: 40,
+    fov: Math.PI / 4,
+    aspect: 1,
+    position: vec3.fromValues(0, 0, 3),
+    up: vec3.fromValues(0, 1, 0),
+    matrices: {
+      view: mat4.create(),
+      projection: mat4.create(),
+      inversProjection: mat4.create()
+    }
+  };
+
+  nearestVertexIndex = null;
+  smoothRotationVelocity = 0;
+  scaleFactor = 1.0;
+  movementActive = false;
+
+  constructor(canvas, items, onActiveItemChange, onMovementChange, onInit = null) {
+    this.canvas = canvas;
+    this.items = items || [];
+    this.onActiveItemChange = onActiveItemChange || (() => {});
+    this.onMovementChange = onMovementChange || (() => {});
+    this.#init(onInit);
+  }
+
+  resize() {
+    this.viewportSize = vec2.set(this.viewportSize || vec2.create(), this.canvas.clientWidth, this.canvas.clientHeight);
+
+    const gl = this.gl;
+    const needsResize = resizeCanvasToDisplaySize(gl.canvas);
+    if (needsResize) {
+      gl.viewport(0, 0, gl.drawingBufferWidth, gl.drawingBufferHeight);
+    }
+
+    this.#updateProjectionMatrix(gl);
+  }
+
+  run(time = 0) {
+    this.#deltaTime = Math.min(32, time - this.#time);
+    this.#time = time;
+    this.#deltaFrames = this.#deltaTime / this.TARGET_FRAME_DURATION;
+    this.#frames += this.#deltaFrames;
+
+    this.#animate(this.#deltaTime);
+    this.#render();
+
+    requestAnimationFrame(t => this.run(t));
+  }
+
+  #init(onInit) {
+    this.gl = this.canvas.getContext('webgl2', { antialias: true, alpha: false });
+    const gl = this.gl;
+    if (!gl) {
+      throw new Error('No WebGL 2 context!');
+    }
+
+    this.viewportSize = vec2.fromValues(this.canvas.clientWidth, this.canvas.clientHeight);
+    this.drawBufferSize = vec2.clone(this.viewportSize);
+
+    this.discProgram = createProgram(gl, [discVertShaderSource, discFragShaderSource], null, {
+      aModelPosition: 0,
+      aModelNormal: 1,
+      aModelUvs: 2,
+      aInstanceMatrix: 3
+    });
+
+    this.discLocations = {
+      aModelPosition: gl.getAttribLocation(this.discProgram, 'aModelPosition'),
+      aModelUvs: gl.getAttribLocation(this.discProgram, 'aModelUvs'),
+      aInstanceMatrix: gl.getAttribLocation(this.discProgram, 'aInstanceMatrix'),
+      uWorldMatrix: gl.getUniformLocation(this.discProgram, 'uWorldMatrix'),
+      uViewMatrix: gl.getUniformLocation(this.discProgram, 'uViewMatrix'),
+      uProjectionMatrix: gl.getUniformLocation(this.discProgram, 'uProjectionMatrix'),
+      uCameraPosition: gl.getUniformLocation(this.discProgram, 'uCameraPosition'),
+      uScaleFactor: gl.getUniformLocation(this.discProgram, 'uScaleFactor'),
+      uRotationAxisVelocity: gl.getUniformLocation(this.discProgram, 'uRotationAxisVelocity'),
+      uTex: gl.getUniformLocation(this.discProgram, 'uTex'),
+      uFrames: gl.getUniformLocation(this.discProgram, 'uFrames'),
+      uItemCount: gl.getUniformLocation(this.discProgram, 'uItemCount'),
+      uAtlasSize: gl.getUniformLocation(this.discProgram, 'uAtlasSize')
+    };
+
+    this.discGeo = new DiscGeometry(56, 1);
+    this.discBuffers = this.discGeo.data;
+    this.discVAO = makeVertexArray(
+      gl,
+      [
+        [makeBuffer(gl, this.discBuffers.vertices, gl.STATIC_DRAW), this.discLocations.aModelPosition, 3],
+        [makeBuffer(gl, this.discBuffers.uvs, gl.STATIC_DRAW), this.discLocations.aModelUvs, 2]
+      ],
+      this.discBuffers.indices
+    );
+
+    this.icoGeo = new IcosahedronGeometry();
+    this.icoGeo.subdivide(1).spherize(this.SPHERE_RADIUS);
+    this.instancePositions = this.icoGeo.vertices.map(v => v.position);
+    this.DISC_INSTANCE_COUNT = this.icoGeo.vertices.length;
+    this.#initDiscInstances(this.DISC_INSTANCE_COUNT);
+
+    this.worldMatrix = mat4.create();
+    this.#initTexture();
+
+    this.control = new ArcballControl(this.canvas, deltaTime => this.#onControlUpdate(deltaTime));
+
+    this.#updateCameraMatrix();
+    this.#updateProjectionMatrix(gl);
+    this.resize();
+
+    if (onInit) onInit(this);
+  }
+
+  #initTexture() {
+    const gl = this.gl;
+    this.tex = createAndSetupTexture(gl, gl.LINEAR, gl.LINEAR, gl.CLAMP_TO_EDGE, gl.CLAMP_TO_EDGE);
+
+    const itemCount = Math.max(1, this.items.length);
+    this.atlasSize = Math.ceil(Math.sqrt(itemCount));
+    const canvas = document.createElement('canvas');
+    const ctx = canvas.getContext('2d');
+    const cellSize = 512;
+
+    canvas.width = this.atlasSize * cellSize;
+    canvas.height = this.atlasSize * cellSize;
+
+    Promise.all(
+      this.items.map(
+        item =>
+          new Promise(resolve => {
+            const img = new Image();
+            img.crossOrigin = 'anonymous';
+            img.onload = () => resolve(img);
+            img.onerror = () => {
+              // Fallback to a placeholder if image fails to load
+              const fallbackImg = new Image();
+              fallbackImg.onload = () => resolve(fallbackImg);
+              fallbackImg.src = 'data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iNTAwIiBoZWlnaHQ9IjUwMCIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIj48cmVjdCB3aWR0aD0iNTAwIiBoZWlnaHQ9IjUwMCIgZmlsbD0iIzMzMzMzMyIvPjx0ZXh0IHg9IjUwJSIgeT0iNTAlIiBmb250LXNpemU9IjE4IiBmaWxsPSJ3aGl0ZSIgdGV4dC1hbmNob3I9Im1pZGRsZSIgZHk9Ii4zZW0iPkltYWdlIE5vdCBGb3VuZDwvdGV4dD48L3N2Zz4=';
+            };
+            img.src = item.image;
+          })
+      )
+    ).then(images => {
+      images.forEach((img, i) => {
+        const x = (i % this.atlasSize) * cellSize;
+        const y = Math.floor(i / this.atlasSize) * cellSize;
+        ctx.drawImage(img, x, y, cellSize, cellSize);
+      });
+
+      gl.bindTexture(gl.TEXTURE_2D, this.tex);
+      gl.texImage2D(gl.TEXTURE_2D, 0, gl.RGBA, gl.RGBA, gl.UNSIGNED_BYTE, canvas);
+      gl.generateMipmap(gl.TEXTURE_2D);
+    });
+  }
+
+  #initDiscInstances(count) {
+    const gl = this.gl;
+    this.discInstances = {
+      matricesArray: new Float32Array(count * 16),
+      matrices: [],
+      buffer: gl.createBuffer()
+    };
+    for (let i = 0; i < count; ++i) {
+      const instanceMatrixArray = new Float32Array(this.discInstances.matricesArray.buffer, i * 16 * 4, 16);
+      instanceMatrixArray.set(mat4.create());
+      this.discInstances.matrices.push(instanceMatrixArray);
+    }
+    gl.bindVertexArray(this.discVAO);
+    gl.bindBuffer(gl.ARRAY_BUFFER, this.discInstances.buffer);
+    gl.bufferData(gl.ARRAY_BUFFER, this.discInstances.matricesArray.byteLength, gl.DYNAMIC_DRAW);
+    const mat4AttribSlotCount = 4;
+    const bytesPerMatrix = 16 * 4;
+    for (let j = 0; j < mat4AttribSlotCount; ++j) {
+      const loc = this.discLocations.aInstanceMatrix + j;
+      gl.enableVertexAttribArray(loc);
+      gl.vertexAttribPointer(loc, 4, gl.FLOAT, false, bytesPerMatrix, j * 4 * 4);
+      gl.vertexAttribDivisor(loc, 1);
+    }
+    gl.bindBuffer(gl.ARRAY_BUFFER, null);
+    gl.bindVertexArray(null);
+  }
+
+  #animate(deltaTime) {
+    const gl = this.gl;
+    this.control.update(deltaTime, this.TARGET_FRAME_DURATION);
+
+    let positions = this.instancePositions.map(p => vec3.transformQuat(vec3.create(), p, this.control.orientation));
+    const scale = 0.25;
+    const SCALE_INTENSITY = 0.6;
+    positions.forEach((p, ndx) => {
+      const s = (Math.abs(p[2]) / this.SPHERE_RADIUS) * SCALE_INTENSITY + (1 - SCALE_INTENSITY);
+      const finalScale = s * scale;
+      const matrix = mat4.create();
+      mat4.multiply(matrix, matrix, mat4.fromTranslation(mat4.create(), vec3.negate(vec3.create(), p)));
+      mat4.multiply(matrix, matrix, mat4.targetTo(mat4.create(), [0, 0, 0], p, [0, 1, 0]));
+      mat4.multiply(matrix, matrix, mat4.fromScaling(mat4.create(), [finalScale, finalScale, finalScale]));
+      mat4.multiply(matrix, matrix, mat4.fromTranslation(mat4.create(), [0, 0, -this.SPHERE_RADIUS]));
+
+      mat4.copy(this.discInstances.matrices[ndx], matrix);
+    });
+
+    gl.bindBuffer(gl.ARRAY_BUFFER, this.discInstances.buffer);
+    gl.bufferSubData(gl.ARRAY_BUFFER, 0, this.discInstances.matricesArray);
+    gl.bindBuffer(gl.ARRAY_BUFFER, null);
+
+    this.smoothRotationVelocity = this.control.rotationVelocity;
+  }
+
+  #render() {
+    const gl = this.gl;
+    gl.useProgram(this.discProgram);
+
+    gl.enable(gl.CULL_FACE);
+    gl.enable(gl.DEPTH_TEST);
+
+    gl.clearColor(0, 0, 0, 0);
+    gl.clear(gl.COLOR_BUFFER_BIT | gl.DEPTH_BUFFER_BIT);
+
+    gl.uniformMatrix4fv(this.discLocations.uWorldMatrix, false, this.worldMatrix);
+    gl.uniformMatrix4fv(this.discLocations.uViewMatrix, false, this.camera.matrices.view);
+    gl.uniformMatrix4fv(this.discLocations.uProjectionMatrix, false, this.camera.matrices.projection);
+    gl.uniform3f(
+      this.discLocations.uCameraPosition,
+      this.camera.position[0],
+      this.camera.position[1],
+      this.camera.position[2]
+    );
+    gl.uniform4f(
+      this.discLocations.uRotationAxisVelocity,
+      this.control.rotationAxis[0],
+      this.control.rotationAxis[1],
+      this.control.rotationAxis[2],
+      this.smoothRotationVelocity * 1.1
+    );
+
+    gl.uniform1i(this.discLocations.uItemCount, this.items.length);
+    gl.uniform1i(this.discLocations.uAtlasSize, this.atlasSize);
+
+    gl.uniform1f(this.discLocations.uFrames, this.#frames);
+    gl.uniform1f(this.discLocations.uScaleFactor, this.scaleFactor);
+    gl.uniform1i(this.discLocations.uTex, 0);
+    gl.activeTexture(gl.TEXTURE0);
+    gl.bindTexture(gl.TEXTURE_2D, this.tex);
+
+    gl.bindVertexArray(this.discVAO);
+    gl.drawElementsInstanced(
+      gl.TRIANGLES,
+      this.discBuffers.indices.length,
+      gl.UNSIGNED_SHORT,
+      0,
+      this.DISC_INSTANCE_COUNT
+    );
+  }
+
+  #updateCameraMatrix() {
+    mat4.targetTo(this.camera.matrix, this.camera.position, [0, 0, 0], this.camera.up);
+    mat4.invert(this.camera.matrices.view, this.camera.matrix);
+  }
+
+  #updateProjectionMatrix(gl) {
+    this.camera.aspect = gl.canvas.clientWidth / gl.canvas.clientHeight;
+    const height = this.SPHERE_RADIUS * 0.35;
+    const distance = this.camera.position[2];
+    if (this.camera.aspect > 1) {
+      this.camera.fov = 2 * Math.atan(height / distance);
+    } else {
+      this.camera.fov = 2 * Math.atan(height / this.camera.aspect / distance);
+    }
+    mat4.perspective(
+      this.camera.matrices.projection,
+      this.camera.fov,
+      this.camera.aspect,
+      this.camera.near,
+      this.camera.far
+    );
+    mat4.invert(this.camera.matrices.inversProjection, this.camera.matrices.projection);
+  }
+
+  #onControlUpdate(deltaTime) {
+    const timeScale = deltaTime / this.TARGET_FRAME_DURATION + 0.0001;
+    let damping = 5 / timeScale;
+    let cameraTargetZ = 3;
+
+    const isMoving = this.control.isPointerDown || Math.abs(this.smoothRotationVelocity) > 0.01;
+
+    if (isMoving !== this.movementActive) {
+      this.movementActive = isMoving;
+      this.onMovementChange(isMoving);
+    }
+
+    if (!this.control.isPointerDown) {
+      const nearestVertexIndex = this.#findNearestVertexIndex();
+      const itemIndex = nearestVertexIndex % Math.max(1, this.items.length);
+      this.onActiveItemChange(itemIndex);
+      const snapDirection = vec3.normalize(vec3.create(), this.#getVertexWorldPosition(nearestVertexIndex));
+      this.control.snapTargetDirection = snapDirection;
+    } else {
+      cameraTargetZ += this.control.rotationVelocity * 80 + 2.5;
+      damping = 7 / timeScale;
+    }
+
+    this.camera.position[2] += (cameraTargetZ - this.camera.position[2]) / damping;
+    this.#updateCameraMatrix();
+  }
+
+  #findNearestVertexIndex() {
+    const n = this.control.snapDirection;
+    const inversOrientation = quat.conjugate(quat.create(), this.control.orientation);
+    const nt = vec3.transformQuat(vec3.create(), n, inversOrientation);
+
+    let maxD = -1;
+    let nearestVertexIndex;
+    for (let i = 0; i < this.instancePositions.length; ++i) {
+      const d = vec3.dot(nt, this.instancePositions[i]);
+      if (d > maxD) {
+        maxD = d;
+        nearestVertexIndex = i;
+      }
+    }
+    return nearestVertexIndex;
+  }
+
+  #getVertexWorldPosition(index) {
+    const nearestVertexPos = this.instancePositions[index];
+    return vec3.transformQuat(vec3.create(), nearestVertexPos, this.control.orientation);
+  }
+}
+
+const defaultItems = [
+  {
+    image: 'https://images.unsplash.com/photo-1564507592333-c60657eea523?w=500',
+    link: '#taj-mahal',
+    title: 'Taj Mahal',
+    description: 'Iconic ivory-white marble mausoleum'
+  }
+];
+
+export default function InfiniteMenu({ items = [] }) {
+  const canvasRef = useRef(null);
+  const router = useRouter();
+  const [activeItem, setActiveItem] = useState(null);
+  const [isMoving, setIsMoving] = useState(false);
+
+  useEffect(() => {
+    const canvas = canvasRef.current;
+    let sketch;
+
+    const handleActiveItem = index => {
+      const itemIndex = index % items.length;
+      setActiveItem(items[itemIndex]);
+    };
+
+    if (canvas) {
+      sketch = new InfiniteGridMenu(canvas, items.length ? items : defaultItems, handleActiveItem, setIsMoving, sk =>
+        sk.run()
+      );
+    }
+
+    const handleResize = () => {
+      if (sketch) {
+        sketch.resize();
+      }
+    };
+
+    window.addEventListener('resize', handleResize);
+    handleResize();
+
+    return () => {
+      window.removeEventListener('resize', handleResize);
+    };
+  }, [items]);
+
+  const handleButtonClick = () => {
+    if (!activeItem?.link) return;
+    if (activeItem.link.startsWith('http')) {
+      window.open(activeItem.link, '_blank');
+    } else {
+      // Handle internal navigation using Next.js router
+      router.push(activeItem.link);
+    }
+  };
+
+  return (
+    <div className="relative w-full h-full bg-gradient-to-br from-background/50 to-surface/30 backdrop-blur-sm rounded-xl overflow-hidden">
+      <canvas
+        id="infinite-grid-menu-canvas"
+        ref={canvasRef}
+        className="cursor-grab w-full h-full overflow-hidden relative outline-none active:cursor-grabbing"
+      />
+
+      {activeItem && (
+        <>
+          <h2
+            className={`
+          select-none
+          absolute
+          font-black
+          text-4xl md:text-6xl lg:text-7xl
+          left-8 md:left-16
+          top-1/2
+          transform
+          translate-x-0 md:translate-x-[20%]
+          -translate-y-1/2
+          transition-all
+          text-text-secondary
+          ease-[cubic-bezier(0.25,0.1,0.25,1.0)]
+          ${
+            isMoving
+              ? 'opacity-0 pointer-events-none duration-[100ms]'
+              : 'opacity-100 pointer-events-auto duration-[500ms]'
+          }
+        `}
+          >
+            {activeItem.title}
+          </h2>
+
+          <p
+            className={`
+          select-none
+          absolute
+          max-w-[15ch] md:max-w-[12ch]
+          text-lg md:text-xl lg:text-2xl
+          top-1/2
+          right-4 md:right-8
+          text-text-secondary
+          transition-all
+          ease-[cubic-bezier(0.25,0.1,0.25,1.0)]
+          ${
+            isMoving
+              ? 'opacity-0 pointer-events-none duration-[100ms] translate-x-[-60%] -translate-y-1/2'
+              : 'opacity-100 pointer-events-auto duration-[500ms] translate-x-[-90%] -translate-y-1/2'
+          }
+        `}
+          >
+            {activeItem.description}
+          </p>
+
+          <div
+            onClick={handleButtonClick}
+            className={`
+          absolute
+          left-1/2
+          z-10
+          w-12 h-12 md:w-16 md:h-16
+          grid
+          place-items-center
+          bg-primary
+          hover:bg-primary/90
+          border-4
+          border-borders
+          rounded-full
+          cursor-pointer
+          transition-all
+          ease-[cubic-bezier(0.25,0.1,0.25,1.0)]
+          hover:scale-110
+          ${
+            isMoving
+              ? 'bottom-[-80px] opacity-0 pointer-events-none duration-[100ms] scale-0 -translate-x-1/2'
+              : 'bottom-12 md:bottom-16 opacity-100 pointer-events-auto duration-[500ms] scale-100 -translate-x-1/2'
+          }
+        `}
+          >
+            <p className="select-none relative text-background text-xl md:text-2xl font-bold">&#x2197;</p>
+          </div>
+        </>
+      )}
+    </div>
+  );
+}

--- a/viraasat/src/app/page.js
+++ b/viraasat/src/app/page.js
@@ -8,27 +8,67 @@ import Community from './components/Community';
 import CTA from './components/CTA';
 import Footer from './components/Footer';
 import ThemeToggle from './components/ThemeToggle';
-import SunTemple from "./components/3dmodels/SunTemple";
-import TajMahal from "./components/3dmodels/TajMahal";
-import QutubMinar from "./components/3dmodels/QutubMinar";
-import RedFort from "./components/3dmodels/RedFort";
-import SanchiStupa from "./components/3dmodels/SanchiStupa";
+import InfiniteMenu from './components/InfiniteMenu';
+
+// Heritage site data with high-quality stock photos
+const heritageItems = [
+  {
+    image: 'https://images.pexels.com/photos/3881104/pexels-photo-3881104.jpeg',
+    link: '/taj-mahal',
+    title: 'Taj Mahal',
+    description: 'Iconic ivory-white marble mausoleum on the Yamuna riverbank'
+  },
+  {
+    image: 'https://images.pexels.com/photos/33928936/pexels-photo-33928936.jpeg',
+    link: '/red-fort',
+    title: 'Red Fort',
+    description: 'Historic fortified palace of the Mughal emperors of India'
+  },
+  {
+    image: 'https://images.pexels.com/photos/16892577/pexels-photo-16892577.jpeg',
+    link: '/qutub-minar',
+    title: 'Qutub Minar',
+    description: 'Tallest brick minaret in the world, UNESCO World Heritage'
+  },
+  {
+    image: 'https://images.pexels.com/photos/6040175/pexels-photo-6040175.jpeg',
+    link: '/sun-temple',
+    title: 'Sun Temple',
+    description: 'Ancient Hindu temple dedicated to the Hindu sun god Surya'
+  },
+  {
+    image: 'https://images.pexels.com/photos/33266890/pexels-photo-33266890.jpeg',
+    link: '/sanchi-stupa',
+    title: 'Sanchi Stupa',
+    description: 'Buddhist complex famous for its Great Stupa'
+  }
+];
 
 export default function Home() {
   return (
     <main className="min-h-screen">
       <ThemeToggle/>
       <Hero/>
-      <h1>Konark Sun Temple</h1>
-      <SunTemple/>
-      <h1>Taj Mahal</h1>
-      <TajMahal/>
-      <h1>Qutub Minar</h1>
-      <QutubMinar/>
-      <h1>Red Fort</h1>
-      <RedFort/>
-      <h1>Sanchi Stupa</h1>
-      <SanchiStupa/>
+      
+      {/* Interactive Heritage Explorer */}
+      <section className="py-20 bg-gradient-to-b from-background to-surface">
+        <div className="max-w-7xl mx-auto px-6">
+          <div className="text-center mb-12">
+            <h2 className="text-4xl md:text-5xl font-bold text-text-primary mb-6">
+              Explore Heritage Sites
+            </h2>
+            <p className="text-xl text-text-secondary max-w-3xl mx-auto">
+              Navigate through India's magnificent heritage sites in an immersive 3D experience. 
+              Drag to rotate and discover the stories behind each monument.
+            </p>
+          </div>
+          
+          <div className="h-[600px] rounded-2xl overflow-hidden shadow-2xl border border-borders/20 bg-surface/20 backdrop-blur-sm">
+            <InfiniteMenu items={heritageItems}/>
+          </div>
+        </div>
+      </section>
+
       <About/>
       <Features/>
       <Showcase/>

--- a/viraasat/src/app/qutub-minar/page.js
+++ b/viraasat/src/app/qutub-minar/page.js
@@ -1,0 +1,138 @@
+'use client'
+
+import Link from 'next/link';
+import { ArrowLeft } from 'lucide-react';
+import ThemeToggle from '../components/ThemeToggle';
+import QutubMinar from '../components/3dmodels/QutubMinar';
+
+export default function QutubMinarPage() {
+  return (
+    <main className="min-h-screen bg-gradient-to-br from-background via-surface/50 to-background">
+      <ThemeToggle />
+      
+      {/* Header */}
+      <div className="relative z-10 pt-8 pb-6">
+        <div className="max-w-7xl mx-auto px-6">
+          <Link 
+            href="/" 
+            className="inline-flex items-center gap-3 text-text-secondary hover:text-text-primary transition-colors duration-300 group"
+          >
+            <ArrowLeft className="w-5 h-5 group-hover:-translate-x-1 transition-transform duration-300" />
+            Back to Heritage Explorer
+          </Link>
+        </div>
+      </div>
+
+      {/* Hero Section */}
+      <section className="py-12">
+        <div className="max-w-7xl mx-auto px-6 text-center">
+          <h1 className="text-5xl md:text-7xl font-bold text-text-primary mb-6 bg-gradient-to-r from-text-primary via-accent to-text-primary bg-clip-text text-transparent">
+            Qutub Minar
+          </h1>
+          <p className="text-xl md:text-2xl text-text-secondary max-w-4xl mx-auto leading-relaxed">
+            Witness the tallest brick minaret in the world, a magnificent example of Indo-Islamic architecture. 
+            This UNESCO World Heritage Site stands as a testament to Delhi's rich medieval history.
+          </p>
+        </div>
+      </section>
+
+      {/* 3D Model Section */}
+      <section className="py-12">
+        <div className="max-w-7xl mx-auto px-6">
+          <div className="bg-surface/20 backdrop-blur-xl rounded-3xl p-8 md:p-12 border border-borders/30 shadow-2xl">
+            <div className="text-center mb-8">
+              <h2 className="text-3xl md:text-4xl font-bold text-text-primary mb-4">
+                Interactive 3D Model
+              </h2>
+              <p className="text-lg text-text-secondary max-w-2xl mx-auto">
+                Explore the intricate carvings and architectural details of this 12th-century masterpiece. Drag to rotate, scroll to zoom.
+              </p>
+            </div>
+            
+            <div className="h-[600px] rounded-2xl overflow-hidden bg-gradient-to-br from-surface/30 to-surface/10 border border-borders/20">
+              <QutubMinar />
+            </div>
+          </div>
+        </div>
+      </section>
+
+      {/* Information Section */}
+      <section className="py-16">
+        <div className="max-w-7xl mx-auto px-6">
+          <div className="grid md:grid-cols-2 gap-12 items-start">
+            <div className="space-y-6">
+              <h3 className="text-3xl font-bold text-text-primary">Historical Significance</h3>
+              <div className="prose prose-lg text-text-secondary space-y-4">
+                <p>
+                  The Qutub Minar was built in the early 13th century by Qutb-ud-din Aibak, the first Muslim ruler of Delhi. 
+                  Construction was later completed by his successor Iltutmish. The minaret was built to celebrate Muslim dominance 
+                  in Delhi after the defeat of the last Hindu kingdom.
+                </p>
+                <p>
+                  Standing at 72.5 meters (238 feet), it remains the tallest brick minaret in the world and showcases 
+                  the brilliant fusion of Indo-Islamic architectural styles that would define the region for centuries.
+                </p>
+              </div>
+            </div>
+            
+            <div className="space-y-6">
+              <h3 className="text-3xl font-bold text-text-primary">Architectural Features</h3>
+              <div className="space-y-4">
+                <div className="bg-surface/30 rounded-xl p-6 backdrop-blur-sm border border-borders/20">
+                  <h4 className="text-xl font-semibold text-text-primary mb-2">Five Stories</h4>
+                  <p className="text-text-secondary">The minaret has five distinct stories, each marked by a projecting balcony</p>
+                </div>
+                <div className="bg-surface/30 rounded-xl p-6 backdrop-blur-sm border border-borders/20">
+                  <h4 className="text-xl font-semibold text-text-primary mb-2">Calligraphy</h4>
+                  <p className="text-text-secondary">Beautiful Arabic calligraphy from the Quran adorns the tower's surface</p>
+                </div>
+                <div className="bg-surface/30 rounded-xl p-6 backdrop-blur-sm border border-borders/20">
+                  <h4 className="text-xl font-semibold text-text-primary mb-2">Red Sandstone</h4>
+                  <p className="text-text-secondary">Built primarily with red sandstone and marble, showcasing exquisite craftsmanship</p>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      {/* Quick Facts */}
+      <section className="py-12 bg-surface/10">
+        <div className="max-w-7xl mx-auto px-6">
+          <h3 className="text-3xl font-bold text-text-primary text-center mb-12">Quick Facts</h3>
+          <div className="grid grid-cols-2 md:grid-cols-4 gap-6">
+            <div className="text-center">
+              <div className="text-3xl font-bold text-accent mb-2">1193</div>
+              <div className="text-text-secondary">Construction Started</div>
+            </div>
+            <div className="text-center">
+              <div className="text-3xl font-bold text-accent mb-2">72.5m</div>
+              <div className="text-text-secondary">Height</div>
+            </div>
+            <div className="text-center">
+              <div className="text-3xl font-bold text-accent mb-2">379</div>
+              <div className="text-text-secondary">Steps to Top</div>
+            </div>
+            <div className="text-center">
+              <div className="text-3xl font-bold text-accent mb-2">1993</div>
+              <div className="text-text-secondary">UNESCO Heritage</div>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      {/* Navigation Footer */}
+      <section className="py-12">
+        <div className="max-w-7xl mx-auto px-6 text-center">
+          <Link 
+            href="/" 
+            className="inline-flex items-center gap-3 bg-accent hover:bg-accent/90 text-white px-8 py-4 rounded-xl font-semibold transition-all duration-300 transform hover:scale-105 shadow-lg hover:shadow-xl"
+          >
+            <ArrowLeft className="w-5 h-5" />
+            Explore More Heritage Sites
+          </Link>
+        </div>
+      </section>
+    </main>
+  );
+}

--- a/viraasat/src/app/red-fort/page.js
+++ b/viraasat/src/app/red-fort/page.js
@@ -1,0 +1,138 @@
+'use client'
+
+import Link from 'next/link';
+import { ArrowLeft } from 'lucide-react';
+import ThemeToggle from '../components/ThemeToggle';
+import RedFort from '../components/3dmodels/RedFort';
+
+export default function RedFortPage() {
+  return (
+    <main className="min-h-screen bg-gradient-to-br from-background via-surface/50 to-background">
+      <ThemeToggle />
+      
+      {/* Header */}
+      <div className="relative z-10 pt-8 pb-6">
+        <div className="max-w-7xl mx-auto px-6">
+          <Link 
+            href="/" 
+            className="inline-flex items-center gap-3 text-text-secondary hover:text-text-primary transition-colors duration-300 group"
+          >
+            <ArrowLeft className="w-5 h-5 group-hover:-translate-x-1 transition-transform duration-300" />
+            Back to Heritage Explorer
+          </Link>
+        </div>
+      </div>
+
+      {/* Hero Section */}
+      <section className="py-12">
+        <div className="max-w-7xl mx-auto px-6 text-center">
+          <h1 className="text-5xl md:text-7xl font-bold text-text-primary mb-6 bg-gradient-to-r from-text-primary via-accent to-text-primary bg-clip-text text-transparent">
+            Red Fort
+          </h1>
+          <p className="text-xl md:text-2xl text-text-secondary max-w-4xl mx-auto leading-relaxed">
+            Discover the historic fortified palace that served as the main residence of the Mughal emperors. 
+            A symbol of India's rich heritage and the site of India's Independence Day celebrations.
+          </p>
+        </div>
+      </section>
+
+      {/* 3D Model Section */}
+      <section className="py-12">
+        <div className="max-w-7xl mx-auto px-6">
+          <div className="bg-surface/20 backdrop-blur-xl rounded-3xl p-8 md:p-12 border border-borders/30 shadow-2xl">
+            <div className="text-center mb-8">
+              <h2 className="text-3xl md:text-4xl font-bold text-text-primary mb-4">
+                Interactive 3D Model
+              </h2>
+              <p className="text-lg text-text-secondary max-w-2xl mx-auto">
+                Explore the magnificent red sandstone walls and intricate Mughal architecture. Drag to rotate, scroll to zoom.
+              </p>
+            </div>
+            
+            <div className="h-[600px] rounded-2xl overflow-hidden bg-gradient-to-br from-surface/30 to-surface/10 border border-borders/20">
+              <RedFort />
+            </div>
+          </div>
+        </div>
+      </section>
+
+      {/* Information Section */}
+      <section className="py-16">
+        <div className="max-w-7xl mx-auto px-6">
+          <div className="grid md:grid-cols-2 gap-12 items-start">
+            <div className="space-y-6">
+              <h3 className="text-3xl font-bold text-text-primary">Historical Significance</h3>
+              <div className="prose prose-lg text-text-secondary space-y-4">
+                <p>
+                  The Red Fort, known as Lal Qila in Hindi, was constructed by the Mughal Emperor Shah Jahan in 1648 
+                  when he shifted his capital from Agra to Delhi. This magnificent fortress served as the main residence 
+                  of the Mughal emperors for nearly 200 years.
+                </p>
+                <p>
+                  The fort is most famous for being the site where India's first Prime Minister, Jawaharlal Nehru, 
+                  raised the Indian national flag on August 15, 1947, marking India's independence from British rule.
+                </p>
+              </div>
+            </div>
+            
+            <div className="space-y-6">
+              <h3 className="text-3xl font-bold text-text-primary">Architectural Features</h3>
+              <div className="space-y-4">
+                <div className="bg-surface/30 rounded-xl p-6 backdrop-blur-sm border border-borders/20">
+                  <h4 className="text-xl font-semibold text-text-primary mb-2">Red Sandstone Walls</h4>
+                  <p className="text-text-secondary">Massive walls built with red sandstone, giving the fort its distinctive name</p>
+                </div>
+                <div className="bg-surface/30 rounded-xl p-6 backdrop-blur-sm border border-borders/20">
+                  <h4 className="text-xl font-semibold text-text-primary mb-2">Diwan-i-Aam</h4>
+                  <p className="text-text-secondary">The Hall of Public Audience where the emperor met common people</p>
+                </div>
+                <div className="bg-surface/30 rounded-xl p-6 backdrop-blur-sm border border-borders/20">
+                  <h4 className="text-xl font-semibold text-text-primary mb-2">Diwan-i-Khas</h4>
+                  <p className="text-text-secondary">The Hall of Private Audience, once home to the famous Peacock Throne</p>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      {/* Quick Facts */}
+      <section className="py-12 bg-surface/10">
+        <div className="max-w-7xl mx-auto px-6">
+          <h3 className="text-3xl font-bold text-text-primary text-center mb-12">Quick Facts</h3>
+          <div className="grid grid-cols-2 md:grid-cols-4 gap-6">
+            <div className="text-center">
+              <div className="text-3xl font-bold text-accent mb-2">1648</div>
+              <div className="text-text-secondary">Construction Started</div>
+            </div>
+            <div className="text-center">
+              <div className="text-3xl font-bold text-accent mb-2">254</div>
+              <div className="text-text-secondary">Acres in Area</div>
+            </div>
+            <div className="text-center">
+              <div className="text-3xl font-bold text-accent mb-2">18m</div>
+              <div className="text-text-secondary">Height of Walls</div>
+            </div>
+            <div className="text-center">
+              <div className="text-3xl font-bold text-accent mb-2">2007</div>
+              <div className="text-text-secondary">UNESCO Heritage</div>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      {/* Navigation Footer */}
+      <section className="py-12">
+        <div className="max-w-7xl mx-auto px-6 text-center">
+          <Link 
+            href="/" 
+            className="inline-flex items-center gap-3 bg-accent hover:bg-accent/90 text-white px-8 py-4 rounded-xl font-semibold transition-all duration-300 transform hover:scale-105 shadow-lg hover:shadow-xl"
+          >
+            <ArrowLeft className="w-5 h-5" />
+            Explore More Heritage Sites
+          </Link>
+        </div>
+      </section>
+    </main>
+  );
+}

--- a/viraasat/src/app/sanchi-stupa/page.js
+++ b/viraasat/src/app/sanchi-stupa/page.js
@@ -1,0 +1,139 @@
+'use client'
+
+import Link from 'next/link';
+import { ArrowLeft } from 'lucide-react';
+import ThemeToggle from '../components/ThemeToggle';
+import SanchiStupa from '../components/3dmodels/SanchiStupa';
+
+export default function SanchiStupaPage() {
+  return (
+    <main className="min-h-screen bg-gradient-to-br from-background via-surface/50 to-background">
+      <ThemeToggle />
+      
+      {/* Header */}
+      <div className="relative z-10 pt-8 pb-6">
+        <div className="max-w-7xl mx-auto px-6">
+          <Link 
+            href="/" 
+            className="inline-flex items-center gap-3 text-text-secondary hover:text-text-primary transition-colors duration-300 group"
+          >
+            <ArrowLeft className="w-5 h-5 group-hover:-translate-x-1 transition-transform duration-300" />
+            Back to Heritage Explorer
+          </Link>
+        </div>
+      </div>
+
+      {/* Hero Section */}
+      <section className="py-12">
+        <div className="max-w-7xl mx-auto px-6 text-center">
+          <h1 className="text-5xl md:text-7xl font-bold text-text-primary mb-6 bg-gradient-to-r from-text-primary via-accent to-text-primary bg-clip-text text-transparent">
+            Sanchi Stupa
+          </h1>
+          <p className="text-xl md:text-2xl text-text-secondary max-w-4xl mx-auto leading-relaxed">
+            Journey to one of the oldest Buddhist monuments in the world. The Great Stupa at Sanchi stands as a 
+            remarkable testament to Buddhist art and architecture, dating back to the 3rd century BCE.
+          </p>
+        </div>
+      </section>
+
+      {/* 3D Model Section */}
+      <section className="py-12">
+        <div className="max-w-7xl mx-auto px-6">
+          <div className="bg-surface/20 backdrop-blur-xl rounded-3xl p-8 md:p-12 border border-borders/30 shadow-2xl">
+            <div className="text-center mb-8">
+              <h2 className="text-3xl md:text-4xl font-bold text-text-primary mb-4">
+                Interactive 3D Model
+              </h2>
+              <p className="text-lg text-text-secondary max-w-2xl mx-auto">
+                Explore the magnificent Great Stupa and its ornate gateways with detailed Buddhist sculptures. Drag to rotate, scroll to zoom.
+              </p>
+            </div>
+            
+            <div className="h-[600px] rounded-2xl overflow-hidden bg-gradient-to-br from-surface/30 to-surface/10 border border-borders/20">
+              <SanchiStupa />
+            </div>
+          </div>
+        </div>
+      </section>
+
+      {/* Information Section */}
+      <section className="py-16">
+        <div className="max-w-7xl mx-auto px-6">
+          <div className="grid md:grid-cols-2 gap-12 items-start">
+            <div className="space-y-6">
+              <h3 className="text-3xl font-bold text-text-primary">Historical Significance</h3>
+              <div className="prose prose-lg text-text-secondary space-y-4">
+                <p>
+                  The Great Stupa at Sanchi was originally commissioned by Emperor Ashoka in the 3rd century BCE. 
+                  It was built to house relics of the Buddha and became one of the most important pilgrimage sites 
+                  in Buddhism. The site contains the oldest stone structures in India.
+                </p>
+                <p>
+                  The complex showcases the evolution of Buddhist art and architecture over several centuries, 
+                  from the Mauryan period through the Gupta period, making it an invaluable repository of ancient 
+                  Indian Buddhist heritage and artistic traditions.
+                </p>
+              </div>
+            </div>
+            
+            <div className="space-y-6">
+              <h3 className="text-3xl font-bold text-text-primary">Architectural Features</h3>
+              <div className="space-y-4">
+                <div className="bg-surface/30 rounded-xl p-6 backdrop-blur-sm border border-borders/20">
+                  <h4 className="text-xl font-semibold text-text-primary mb-2">Great Stupa</h4>
+                  <p className="text-text-secondary">The main hemispherical dome structure, 36.6 meters in diameter</p>
+                </div>
+                <div className="bg-surface/30 rounded-xl p-6 backdrop-blur-sm border border-borders/20">
+                  <h4 className="text-xl font-semibold text-text-primary mb-2">Four Toranas</h4>
+                  <p className="text-text-secondary">Ornate gateways with intricate carvings depicting Jataka tales</p>
+                </div>
+                <div className="bg-surface/30 rounded-xl p-6 backdrop-blur-sm border border-borders/20">
+                  <h4 className="text-xl font-semibold text-text-primary mb-2">Harmika</h4>
+                  <p className="text-text-secondary">Square railing on top representing the abode of the gods</p>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      {/* Quick Facts */}
+      <section className="py-12 bg-surface/10">
+        <div className="max-w-7xl mx-auto px-6">
+          <h3 className="text-3xl font-bold text-text-primary text-center mb-12">Quick Facts</h3>
+          <div className="grid grid-cols-2 md:grid-cols-4 gap-6">
+            <div className="text-center">
+              <div className="text-3xl font-bold text-accent mb-2">3rd</div>
+              <div className="text-text-secondary">Century BCE</div>
+            </div>
+            <div className="text-center">
+              <div className="text-3xl font-bold text-accent mb-2">36.6m</div>
+              <div className="text-text-secondary">Stupa Diameter</div>
+            </div>
+            <div className="text-center">
+              <div className="text-3xl font-bold text-accent mb-2">4</div>
+              <div className="text-text-secondary">Ornate Gateways</div>
+            </div>
+            <div className="text-center">
+              <div className="text-3xl font-bold text-accent mb-2">1989</div>
+              <div className="text-text-secondary">UNESCO Heritage</div>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      {/* Navigation Footer */}
+      <section className="py-12">
+        <div className="max-w-7xl mx-auto px-6 text-center">
+          <Link 
+            href="/" 
+            className="inline-flex items-center gap-3 bg-accent hover:bg-accent/90 text-white px-8 py-4 rounded-xl font-semibold transition-all duration-300 transform hover:scale-105 shadow-lg hover:shadow-xl"
+          >
+            <ArrowLeft className="w-5 h-5" />
+            Explore More Heritage Sites
+          </Link>
+        </div>
+      </section>
+    </main>
+  );
+}

--- a/viraasat/src/app/sun-temple/page.js
+++ b/viraasat/src/app/sun-temple/page.js
@@ -1,0 +1,139 @@
+'use client'
+
+import Link from 'next/link';
+import { ArrowLeft } from 'lucide-react';
+import ThemeToggle from '../components/ThemeToggle';
+import SunTemple from '../components/3dmodels/SunTemple';
+
+export default function SunTemplePage() {
+  return (
+    <main className="min-h-screen bg-gradient-to-br from-background via-surface/50 to-background">
+      <ThemeToggle />
+      
+      {/* Header */}
+      <div className="relative z-10 pt-8 pb-6">
+        <div className="max-w-7xl mx-auto px-6">
+          <Link 
+            href="/" 
+            className="inline-flex items-center gap-3 text-text-secondary hover:text-text-primary transition-colors duration-300 group"
+          >
+            <ArrowLeft className="w-5 h-5 group-hover:-translate-x-1 transition-transform duration-300" />
+            Back to Heritage Explorer
+          </Link>
+        </div>
+      </div>
+
+      {/* Hero Section */}
+      <section className="py-12">
+        <div className="max-w-7xl mx-auto px-6 text-center">
+          <h1 className="text-5xl md:text-7xl font-bold text-text-primary mb-6 bg-gradient-to-r from-text-primary via-accent to-text-primary bg-clip-text text-transparent">
+            Konark Sun Temple
+          </h1>
+          <p className="text-xl md:text-2xl text-text-secondary max-w-4xl mx-auto leading-relaxed">
+            Marvel at the architectural wonder dedicated to the Hindu sun god Surya. Known as the "Black Pagoda," 
+            this 13th-century temple is conceived as a gigantic chariot with elaborately carved stone wheels.
+          </p>
+        </div>
+      </section>
+
+      {/* 3D Model Section */}
+      <section className="py-12">
+        <div className="max-w-7xl mx-auto px-6">
+          <div className="bg-surface/20 backdrop-blur-xl rounded-3xl p-8 md:p-12 border border-borders/30 shadow-2xl">
+            <div className="text-center mb-8">
+              <h2 className="text-3xl md:text-4xl font-bold text-text-primary mb-4">
+                Interactive 3D Model
+              </h2>
+              <p className="text-lg text-text-secondary max-w-2xl mx-auto">
+                Explore the intricate stone carvings and the unique chariot design of this architectural masterpiece. Drag to rotate, scroll to zoom.
+              </p>
+            </div>
+            
+            <div className="h-[600px] rounded-2xl overflow-hidden bg-gradient-to-br from-surface/30 to-surface/10 border border-borders/20">
+              <SunTemple />
+            </div>
+          </div>
+        </div>
+      </section>
+
+      {/* Information Section */}
+      <section className="py-16">
+        <div className="max-w-7xl mx-auto px-6">
+          <div className="grid md:grid-cols-2 gap-12 items-start">
+            <div className="space-y-6">
+              <h3 className="text-3xl font-bold text-text-primary">Historical Significance</h3>
+              <div className="prose prose-lg text-text-secondary space-y-4">
+                <p>
+                  The Konark Sun Temple was built in the 13th century by King Narasimhadeva I of the Eastern Ganga Dynasty. 
+                  This magnificent temple is designed in the shape of a gigantic chariot with 24 wheels drawn by seven horses, 
+                  all carved from stone, representing the sun god Surya's chariot.
+                </p>
+                <p>
+                  The temple is famous for its exceptional architecture and stone carvings that depict various aspects of life, 
+                  including erotic sculptures, celestial beings, animals, and floral patterns, showcasing the artistic excellence 
+                  of ancient Indian craftsmanship.
+                </p>
+              </div>
+            </div>
+            
+            <div className="space-y-6">
+              <h3 className="text-3xl font-bold text-text-primary">Architectural Features</h3>
+              <div className="space-y-4">
+                <div className="bg-surface/30 rounded-xl p-6 backdrop-blur-sm border border-borders/20">
+                  <h4 className="text-xl font-semibold text-text-primary mb-2">Chariot Wheels</h4>
+                  <p className="text-text-secondary">24 intricately carved stone wheels, each about 10 feet in diameter</p>
+                </div>
+                <div className="bg-surface/30 rounded-xl p-6 backdrop-blur-sm border border-borders/20">
+                  <h4 className="text-xl font-semibold text-text-primary mb-2">Seven Horses</h4>
+                  <p className="text-text-secondary">Seven stone horses represent the seven days of the week</p>
+                </div>
+                <div className="bg-surface/30 rounded-xl p-6 backdrop-blur-sm border border-borders/20">
+                  <h4 className="text-xl font-semibold text-text-primary mb-2">Kalinga Architecture</h4>
+                  <p className="text-text-secondary">Built in the traditional Kalinga architectural style of Odisha</p>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      {/* Quick Facts */}
+      <section className="py-12 bg-surface/10">
+        <div className="max-w-7xl mx-auto px-6">
+          <h3 className="text-3xl font-bold text-text-primary text-center mb-12">Quick Facts</h3>
+          <div className="grid grid-cols-2 md:grid-cols-4 gap-6">
+            <div className="text-center">
+              <div className="text-3xl font-bold text-accent mb-2">1250</div>
+              <div className="text-text-secondary">Built Around</div>
+            </div>
+            <div className="text-center">
+              <div className="text-3xl font-bold text-accent mb-2">24</div>
+              <div className="text-text-secondary">Stone Wheels</div>
+            </div>
+            <div className="text-center">
+              <div className="text-3xl font-bold text-accent mb-2">7</div>
+              <div className="text-text-secondary">Stone Horses</div>
+            </div>
+            <div className="text-center">
+              <div className="text-3xl font-bold text-accent mb-2">1984</div>
+              <div className="text-text-secondary">UNESCO Heritage</div>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      {/* Navigation Footer */}
+      <section className="py-12">
+        <div className="max-w-7xl mx-auto px-6 text-center">
+          <Link 
+            href="/" 
+            className="inline-flex items-center gap-3 bg-accent hover:bg-accent/90 text-white px-8 py-4 rounded-xl font-semibold transition-all duration-300 transform hover:scale-105 shadow-lg hover:shadow-xl"
+          >
+            <ArrowLeft className="w-5 h-5" />
+            Explore More Heritage Sites
+          </Link>
+        </div>
+      </section>
+    </main>
+  );
+}

--- a/viraasat/src/app/taj-mahal/page.js
+++ b/viraasat/src/app/taj-mahal/page.js
@@ -1,0 +1,137 @@
+'use client'
+
+import Link from 'next/link';
+import { ArrowLeft } from 'lucide-react';
+import ThemeToggle from '../components/ThemeToggle';
+import TajMahal from '../components/3dmodels/TajMahal';
+
+export default function TajMahalPage() {
+  return (
+    <main className="min-h-screen bg-gradient-to-br from-background via-surface/50 to-background">
+      <ThemeToggle />
+      
+      {/* Header */}
+      <div className="relative z-10 pt-8 pb-6">
+        <div className="max-w-7xl mx-auto px-6">
+          <Link 
+            href="/" 
+            className="inline-flex items-center gap-3 text-text-secondary hover:text-text-primary transition-colors duration-300 group"
+          >
+            <ArrowLeft className="w-5 h-5 group-hover:-translate-x-1 transition-transform duration-300" />
+            Back to Heritage Explorer
+          </Link>
+        </div>
+      </div>
+
+      {/* Hero Section */}
+      <section className="py-12">
+        <div className="max-w-7xl mx-auto px-6 text-center">
+          <h1 className="text-5xl md:text-7xl font-bold text-text-primary mb-6 bg-gradient-to-r from-text-primary via-accent to-text-primary bg-clip-text text-transparent">
+            Taj Mahal
+          </h1>
+          <p className="text-xl md:text-2xl text-text-secondary max-w-4xl mx-auto leading-relaxed">
+            Experience the magnificent ivory-white marble mausoleum built on the banks of the Yamuna river. 
+            A symbol of eternal love and one of the Seven Wonders of the World.
+          </p>
+        </div>
+      </section>
+
+      {/* 3D Model Section */}
+      <section className="py-12">
+        <div className="max-w-7xl mx-auto px-6">
+          <div className="bg-surface/20 backdrop-blur-xl rounded-3xl p-8 md:p-12 border border-borders/30 shadow-2xl">
+            <div className="text-center mb-8">
+              <h2 className="text-3xl md:text-4xl font-bold text-text-primary mb-4">
+                Interactive 3D Model
+              </h2>
+              <p className="text-lg text-text-secondary max-w-2xl mx-auto">
+                Explore every detail of this architectural masterpiece. Drag to rotate, scroll to zoom.
+              </p>
+            </div>
+            
+            <div className="h-[600px] rounded-2xl overflow-hidden bg-gradient-to-br from-surface/30 to-surface/10 border border-borders/20">
+              <TajMahal />
+            </div>
+          </div>
+        </div>
+      </section>
+
+      {/* Information Section */}
+      <section className="py-16">
+        <div className="max-w-7xl mx-auto px-6">
+          <div className="grid md:grid-cols-2 gap-12 items-start">
+            <div className="space-y-6">
+              <h3 className="text-3xl font-bold text-text-primary">Historical Significance</h3>
+              <div className="prose prose-lg text-text-secondary space-y-4">
+                <p>
+                  The Taj Mahal was commissioned in 1632 by the Mughal emperor Shah Jahan to house the tomb of his beloved wife, Mumtaz Mahal. 
+                  This magnificent mausoleum took over 20 years to complete and represents the finest example of Mughal architecture.
+                </p>
+                <p>
+                  Built using white marble that appears to change color throughout the day, the Taj Mahal combines elements from Islamic, 
+                  Persian, Ottoman Turkish and Indian architectural styles.
+                </p>
+              </div>
+            </div>
+            
+            <div className="space-y-6">
+              <h3 className="text-3xl font-bold text-text-primary">Architectural Features</h3>
+              <div className="space-y-4">
+                <div className="bg-surface/30 rounded-xl p-6 backdrop-blur-sm border border-borders/20">
+                  <h4 className="text-xl font-semibold text-text-primary mb-2">Central Dome</h4>
+                  <p className="text-text-secondary">The main dome rises 115 feet and is surrounded by four smaller domes</p>
+                </div>
+                <div className="bg-surface/30 rounded-xl p-6 backdrop-blur-sm border border-borders/20">
+                  <h4 className="text-xl font-semibold text-text-primary mb-2">Minarets</h4>
+                  <p className="text-text-secondary">Four 130-foot tall minarets frame the tomb, each slightly tilted outward</p>
+                </div>
+                <div className="bg-surface/30 rounded-xl p-6 backdrop-blur-sm border border-borders/20">
+                  <h4 className="text-xl font-semibold text-text-primary mb-2">Inlay Work</h4>
+                  <p className="text-text-secondary">Intricate pietra dura with precious and semi-precious stones</p>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      {/* Quick Facts */}
+      <section className="py-12 bg-surface/10">
+        <div className="max-w-7xl mx-auto px-6">
+          <h3 className="text-3xl font-bold text-text-primary text-center mb-12">Quick Facts</h3>
+          <div className="grid grid-cols-2 md:grid-cols-4 gap-6">
+            <div className="text-center">
+              <div className="text-3xl font-bold text-accent mb-2">1632</div>
+              <div className="text-text-secondary">Construction Started</div>
+            </div>
+            <div className="text-center">
+              <div className="text-3xl font-bold text-accent mb-2">22</div>
+              <div className="text-text-secondary">Years to Build</div>
+            </div>
+            <div className="text-center">
+              <div className="text-3xl font-bold text-accent mb-2">20,000</div>
+              <div className="text-text-secondary">Workers Involved</div>
+            </div>
+            <div className="text-center">
+              <div className="text-3xl font-bold text-accent mb-2">1983</div>
+              <div className="text-text-secondary">UNESCO Heritage</div>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      {/* Navigation Footer */}
+      <section className="py-12">
+        <div className="max-w-7xl mx-auto px-6 text-center">
+          <Link 
+            href="/" 
+            className="inline-flex items-center gap-3 bg-accent hover:bg-accent/90 text-white px-8 py-4 rounded-xl font-semibold transition-all duration-300 transform hover:scale-105 shadow-lg hover:shadow-xl"
+          >
+            <ArrowLeft className="w-5 h-5" />
+            Explore More Heritage Sites
+          </Link>
+        </div>
+      </section>
+    </main>
+  );
+}


### PR DESCRIPTION
- Removed individual 3D model components from the main page and replaced them with an interactive InfiniteMenu showcasing heritage sites.
- Added individual pages for Qutub Minar, Red Fort, Sanchi Stupa, Sun Temple, and Taj Mahal, each featuring a detailed description, historical significance, architectural features, and interactive 3D models.
- Enhanced navigation with back links to the main heritage explorer page.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Introduced an interactive 3D Heritage Explorer with an infinite scrolling menu of items.
  - Added dedicated exhibit pages for Taj Mahal, Qutub Minar, Red Fort, Sanchi Stupa, and Sun Temple.
  - Implemented animated number counters for impact statistics.

- Refactor
  - Replaced manual counting logic with a reusable animated counter component, improving performance and consistency.

- Chores
  - Added new animation and math libraries to support interactive visuals and motion.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->